### PR TITLE
ci: fix release and build workflow failures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,10 +27,10 @@ jobs:
         node-version: [20.x, 22.x]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -71,13 +71,13 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
         
     - name: Use Node.js 20.x
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 20.x
         cache: 'npm'

--- a/.github/workflows/refresh-connectors.yml
+++ b/.github/workflows/refresh-connectors.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,21 +158,26 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
           
       - name: Install dependencies
         run: npm ci
         
+      - name: Setup virtual display for VS Code tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+
       - name: Lint, build and test
         run: |
           npm run lint:check
           npm run compile  
           npm run webpack
-          npm test
+          xvfb-run -a npm test
           
       - name: Package extension
-        run: npm run package
+        run: npm run package -- --out "sentinel-as-code-toolkit-${{ needs.check-release.outputs.version }}.vsix"
         
       - name: Delete existing release and tag (if manual trigger with overwrite)
         if: needs.check-release.outputs.is-manual-trigger == 'true' && github.event.inputs.overwrite_existing == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
       
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2  # Need previous commit to compare
           
@@ -153,10 +153,10 @@ jobs:
       
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## Summary

Fixes the two failing GitHub Actions workflows.

## Automated Release (`release.yaml`)

The `release` job failed on the v26.7.1 merge because it ran `npm test` on a headless runner with no X display, so the VS Code test host crashed:

```
[ERROR] Missing X server or $DISPLAY
Failed to run tests - Exit code: SIGSEGV
```

- Added an xvfb setup step and run the tests via `xvfb-run -a npm test` (matching `build.yaml`).
- Bumped the release job to **Node 22** - `@vscode/vsce` 3.9.2 needs Node >= 20 and `@vscode/test-electron` needs >= 22, but the job was pinned to Node 18.
- The package step now outputs `sentinel-as-code-toolkit-<version>.vsix` so the release upload glob matches the artifact. It previously produced `sentinelcodeguard-<version>.vsix` and uploaded nothing.

## Build and Update Data (`build.yaml`)

- Updated the build matrix from Node `[18.x, 20.x]` to `[20.x, 22.x]` for compatibility with the pinned tooling.

## Validation

- Both files parse cleanly (js-yaml).
- The failed release run confirmed lint, compile, and webpack already pass on the current code; only the display-less test step failed.

## After merge

- `build.yaml` runs on the push to `main` and should go green.
- `release.yaml` only auto-triggers when `package.json` changes; to publish v26.7.1, run **Automated Release** manually via workflow_dispatch.
