### PR TITLE
CI workflow fixes, custom data-connector registration, and catalogue expansion

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,10 +27,10 @@ jobs:
         node-version: [20.x, 22.x]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -71,13 +71,13 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
         
     - name: Use Node.js 20.x
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 20.x
         cache: 'npm'

--- a/.github/workflows/refresh-connectors.yml
+++ b/.github/workflows/refresh-connectors.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,21 +158,26 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
           
       - name: Install dependencies
         run: npm ci
         
+      - name: Setup virtual display for VS Code tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+
       - name: Lint, build and test
         run: |
           npm run lint:check
           npm run compile  
           npm run webpack
-          npm test
+          xvfb-run -a npm test
           
       - name: Package extension
-        run: npm run package
+        run: npm run package -- --out "sentinel-as-code-toolkit-${{ needs.check-release.outputs.version }}.vsix"
         
       - name: Delete existing release and tag (if manual trigger with overwrite)
         if: needs.check-release.outputs.is-manual-trigger == 'true' && github.event.inputs.overwrite_existing == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
       
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2  # Need previous commit to compare
           
@@ -153,10 +153,10 @@ jobs:
       
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A complete detection-as-code authoring environment for Microsoft Sentinel and Mi
 - **Validate** against the Sentinel and Defender XDR schemas, plus multi-framework MITRE ATT&CK (Enterprise, Mobile, and ICS; v14 to v16).
 - **Format** every Sentinel-as-Code content type into canonical shape — analytics rules, hunting queries, and parsers (YAML), and automation rules, summary rules, watchlists, workbooks, and playbooks (JSON).
 - **Scaffold** new hunting queries, parsers, summary rules, and automation rules from their documented schemas.
-- **Auto-fill** a rule's `requiredDataConnectors` from the KQL tables in its query, using the bundled Content Hub mapping.
+- **Auto-fill** a rule's `requiredDataConnectors` from the KQL tables in its query, using the bundled Content Hub mapping — and register your own custom `_CL` tables in a workspace `.sentinel-connectors.json` when they aren't in the catalogue.
 - **Build** deployment-ready watchlists from a CSV or TSV.
 - **Decompile** single or bulk `Microsoft.SecurityInsights/alertRules` ARM templates into clean YAML.
 - **Convert** Microsoft Defender XDR custom detections between repository YAML and deployable Microsoft Graph `detectionRule` JSON, and format portal exports into repository-ready files.
@@ -60,7 +60,7 @@ The toolkit is focused on authoring and repository hygiene. It does **not** depl
 - **Formatting** — canonical field ordering, ISO 8601 duration correction, and structure tidy-up (`Shift+Alt+F`).
 - **Templates** — Standard and Near-Real-Time (NRT) analytics-rule starting points, plus hunting query, parser, summary rule, automation rule, watchlist, and Defender detection templates. See [Templates](#templates).
 - **Multi-framework MITRE ATT&CK** — validate tactics and techniques against the Enterprise, Mobile, and ICS matrices (v14 to v16 selectable).
-- **Required-connector auto-fill** — read the KQL tables in a rule's `query` and populate `requiredDataConnectors` from the bundled Content Hub table-to-connector mapping, in canonical order.
+- **Required-connector auto-fill** — read the KQL tables in a rule's `query` and populate `requiredDataConnectors` from the bundled Content Hub table-to-connector mapping (including Azure Monitor platform tables, UEBA, and Microsoft Entra ID tables), in canonical order. Unknown custom (`_CL`) tables can be registered on the spot in a workspace-local `.sentinel-connectors.json`, so they resolve automatically on future runs.
 - **Bulk maintenance** — validate and normalise every rule in the workspace, and regenerate rule IDs in bulk.
 
 ### Hunting queries
@@ -133,6 +133,7 @@ The toolkit **formats and validates** Defender XDR custom detections for a Senti
 1. Open an analytics rule that has a `query`.
 2. Run **Sentinel-As-Code: Populate Required Data Connectors from Query** (or right-click the file).
 3. The toolkit reads the KQL tables, matches them to connectors using the bundled Content Hub table mapping, and writes `requiredDataConnectors` in canonical order — no manual lookup needed.
+4. If a table isn't in the catalogue — typically a custom `_CL` table such as `TailscaleAudit_CL` — the toolkit offers to register it inline: accept the derived connector id (or type your own), and it's added to a workspace-local `.sentinel-connectors.json` and included in the rule. Registered connectors are picked up automatically on later runs. See [Custom connectors](#custom-connectors-sentinel-connectorsjson).
 
 ---
 
@@ -191,7 +192,7 @@ Every other template — Standard Rule, NRT Rule, Custom Detection, Hunting Quer
 | Sentinel-As-Code: Create Watchlist from CSV | Convert the active CSV/TSV into a deployment-ready watchlist (watchlist.json + data file) |
 | Sentinel-As-Code: New Sentinel-as-Code Content... | Pick and scaffold any content type (analytics rule, hunting query, parser, summary rule, automation rule, watchlist) |
 | Sentinel-As-Code: New Hunting Query / New Parser / New Summary Rule / New Automation Rule | Scaffold a specific content type from its documented schema |
-| Sentinel-As-Code: Populate Required Data Connectors from Query | Match the rule's KQL tables to connectors and fill `requiredDataConnectors` automatically |
+| Sentinel-As-Code: Populate Required Data Connectors from Query | Match the rule's KQL tables to connectors and fill `requiredDataConnectors`; optionally register unknown `_CL` tables in `.sentinel-connectors.json` |
 | Sentinel-As-Code: Fix Field Order | Reorder fields to the canonical schema order (`Ctrl/Cmd+Shift+F`) |
 | Sentinel-As-Code: Format Sentinel Rule | Format and tidy the rule structure |
 | Sentinel-As-Code: Format Sentinel Content (Auto-detect) | Detect the content type and format it (analytics rules, hunting queries, and JSON content) |
@@ -240,7 +241,6 @@ Add glob patterns to `sentinelAsCode.validation.excludePatterns` to skip validat
     "**/test/**",
     "**/tests/**",
     "**/*.draft.yaml",
-    "**/*.template.yaml",
     "**/backup/**",
     "**/.archive/**"
   ]
@@ -248,6 +248,8 @@ Add glob patterns to `sentinelAsCode.validation.excludePatterns` to skip validat
 ```
 
 Exclusions are additive: with no patterns configured (the default), every candidate file is validated as before.
+
+Scaffolding templates (`*.template.yaml`) are always skipped automatically — they contain `{{PLACEHOLDER}}` tokens (such as `id: {{GUID}}`) and are not deployable rules, so they never surface in the Problems panel regardless of your `excludePatterns`.
 
 ### MITRE ATT&CK
 
@@ -265,6 +267,29 @@ Exclusions are additive: with no patterns configured (the default), every candid
 |---------|---------|-------------|
 | `sentinelAsCode.connectors.validationMode` | `"permissive"` | `strict`, `workspace`, or `permissive` |
 | `sentinelAsCode.connectors.customConnectors` | `[]` | Additional connector IDs to recognise |
+
+#### Custom connectors (`.sentinel-connectors.json`)
+
+Place a `.sentinel-connectors.json` file at a workspace-folder root to teach the toolkit about connectors and tables that aren't in the bundled Content Hub catalogue — most commonly your own custom (`_CL`) tables from a Codeless Connector or Logs Ingestion pipeline. **Populate Required Data Connectors from Query** reads this file alongside the bundled catalogue, and writes to it when you register an unknown table inline.
+
+Each entry mirrors the bundled catalogue shape:
+
+```json
+{
+  "connectors": [
+    {
+      "connectorId": "TailscaleAudit",
+      "connectorTitle": "TailscaleAudit",
+      "descriptionMarkdown": "",
+      "publisher": "Custom",
+      "source": "",
+      "tables": ["TailscaleAudit_CL"]
+    }
+  ]
+}
+```
+
+Custom connectors are loaded per workspace folder and take part in the same table-to-connector matching as the built-in catalogue.
 
 ### Conversion settings
 

--- a/data/connectors.json
+++ b/data/connectors.json
@@ -9,6 +9,33 @@
   },
   "tablesByConnector": [
     {
+      "connectorId": "AzureMonitor",
+      "connectorTitle": "Azure Monitor / Log Analytics platform",
+      "descriptionMarkdown": "Core Log Analytics / Azure Monitor workspace tables that are always available and require no data connector.",
+      "publisher": "Microsoft",
+      "source": "Platform",
+      "tables": [
+        "Heartbeat",
+        "LAQueryLogs",
+        "Operation",
+        "Usage"
+      ]
+    },
+    {
+      "connectorId": "MicrosoftSentinelUEBA",
+      "connectorTitle": "Microsoft Sentinel UEBA",
+      "descriptionMarkdown": "User and Entity Behavior Analytics (UEBA) tables, populated when UEBA is enabled on the workspace. UEBA is a Microsoft Sentinel feature rather than a Content Hub data connector.",
+      "publisher": "Microsoft",
+      "source": "Platform",
+      "tables": [
+        "Anomalies",
+        "BehaviorAnalytics",
+        "IdentityInfo",
+        "UserAccessAnalytics",
+        "UserPeerAnalytics"
+      ]
+    },
+    {
       "connectorId": "DarktraceAma",
       "connectorTitle": "[Deprecated] AI Analyst Darktrace via AMA",
       "descriptionMarkdown": "The Darktrace connector lets users connect Darktrace Model Breaches in real-time with Microsoft Sentinel, allowing creation of custom Dashboards, Workbooks, Notebooks and Custom Alerts to improve investigation.  Microsoft Sentinel's enhanced visibility into Darktrace logs enables monitoring and mitigation of security threats.",
@@ -4437,16 +4464,20 @@
       "publisher": "Microsoft",
       "source": "Solutions/Microsoft Entra ID",
       "tables": [
+        "AADManagedIdentitySignInLogs",
         "AADNonInteractiveUserSignInLogs",
+        "AADProvisioningLogs",
         "AADRiskyServicePrincipals",
+        "AADRiskyUsers",
         "AADServicePrincipalRiskEvents",
         "AADServicePrincipalSignInLogs",
+        "AADUserRiskEvents",
         "ADFSSignInLogs",
-        "Anomalies",
         "AuditLogs",
-        "BehaviorAnalytics",
-        "DeviceInfo",
-        "IdentityInfo",
+        "EnrichedOffice365AuditLogs",
+        "MicrosoftGraphActivityLogs",
+        "NetworkAccessTraffic",
+        "RemoteNetworkHealthLogs",
         "SigninLogs"
       ]
     },

--- a/scripts/extract-connectors.mjs
+++ b/scripts/extract-connectors.mjs
@@ -41,7 +41,65 @@ const OUTPUT_FILE = fileURLToPath(new URL('../data/connectors.json', import.meta
 const CONNECTOR_TABLE_OVERRIDES = {
   // The Office 365 connector streams only the unified OfficeActivity table.
   Office365: ['OfficeActivity'],
+  // The Microsoft Entra ID connector's authoritative data types, as listed on the
+  // connector page. The solution-level union both misses the sign-in/audit streams
+  // (e.g. MicrosoftGraphActivityLogs, AADProvisioningLogs) and over-attributes
+  // UEBA/Defender tables (Anomalies, BehaviorAnalytics, DeviceInfo, IdentityInfo)
+  // that are ingested by their own connectors.
+  AzureActiveDirectory: [
+    'AADManagedIdentitySignInLogs',
+    'AADNonInteractiveUserSignInLogs',
+    'AADProvisioningLogs',
+    'AADRiskyServicePrincipals',
+    'AADRiskyUsers',
+    'AADServicePrincipalRiskEvents',
+    'AADServicePrincipalSignInLogs',
+    'AADUserRiskEvents',
+    'ADFSSignInLogs',
+    'AuditLogs',
+    'EnrichedOffice365AuditLogs',
+    'MicrosoftGraphActivityLogs',
+    'NetworkAccessTraffic',
+    'RemoteNetworkHealthLogs',
+    'SigninLogs',
+  ],
 };
+
+// ---------------------------------------------------------------------------
+// Synthetic connectors for tables the Content Hub Solutions Analyzer does not
+// model. Core Log Analytics / Azure Monitor workspace tables (Usage, Operation,
+// Heartbeat, LAQueryLogs) are always present and belong to no data connector, so
+// they are grouped under a platform pseudo-connector rather than being left
+// unmatched or falsely attributed to an unrelated solution. These are ADDED to
+// the connector map as full entries (they do not replace CSV-derived data).
+// ---------------------------------------------------------------------------
+
+const EXTRA_CONNECTORS = [
+  {
+    connectorId: 'AzureMonitor',
+    connectorTitle: 'Azure Monitor / Log Analytics platform',
+    publisher: 'Microsoft',
+    source: 'Platform',
+    descriptionMarkdown:
+      'Core Log Analytics / Azure Monitor workspace tables that are always available and require no data connector.',
+    tables: ['Heartbeat', 'LAQueryLogs', 'Operation', 'Usage'],
+  },
+  {
+    connectorId: 'MicrosoftSentinelUEBA',
+    connectorTitle: 'Microsoft Sentinel UEBA',
+    publisher: 'Microsoft',
+    source: 'Platform',
+    descriptionMarkdown:
+      'User and Entity Behavior Analytics (UEBA) tables, populated when UEBA is enabled on the workspace. UEBA is a Microsoft Sentinel feature rather than a Content Hub data connector, so the Solutions Analyzer does not model it.',
+    tables: [
+      'Anomalies',
+      'BehaviorAnalytics',
+      'IdentityInfo',
+      'UserAccessAnalytics',
+      'UserPeerAnalytics',
+    ],
+  },
+];
 
 // ---------------------------------------------------------------------------
 // RFC 4180 CSV parser (dependency-free). Handles quoted fields with embedded
@@ -321,6 +379,19 @@ async function main() {
     }
   }
   console.log(`  Enriched from existing data: filled ${filled}, preserved ${preserved}`);
+
+  // Inject synthetic platform connectors (core Log Analytics tables that are
+  // always present and belong to no Content Hub data connector).
+  for (const extra of EXTRA_CONNECTORS) {
+    byId.set(extra.connectorId, {
+      connectorId: extra.connectorId,
+      connectorTitle: extra.connectorTitle,
+      descriptionMarkdown: extra.descriptionMarkdown || '',
+      publisher: extra.publisher || '',
+      source: extra.source || 'Platform',
+      tables: new Set(extra.tables),
+    });
+  }
 
   // Finalise: sort tables, collapse single-table lists to a string (matching the
   // existing connectors.json shape consumed by ConnectorLoader), collect counts.

--- a/src/commands/content/contentCommands.ts
+++ b/src/commands/content/contentCommands.ts
@@ -92,12 +92,99 @@ export class ContentCommands {
             return;
         }
 
-        const connectors = ConnectorLoader.suggestRequiredDataConnectorsForQuery(parsed.query);
-        if (connectors.length === 0) {
+        const choices = ConnectorLoader.getQueryTableConnectorChoices(parsed.query);
+        const unmatchedCustomTables = ConnectorLoader.getUnmatchedCustomTablesForQuery(parsed.query);
+        if (choices.length === 0 && unmatchedCustomTables.length === 0) {
             vscode.window.showWarningMessage('No known Log Analytics tables were found in the query, so no connectors could be matched.');
             return;
         }
 
+        // Resolve each table to a connector, prompting when a table is provided by more than one.
+        const byConnector = new Map<string, string[]>();
+        for (const choice of choices) {
+            let connectorId = choice.connectors[0].id;
+            if (choice.connectors.length > 1) {
+                const items: Array<vscode.QuickPickItem & { connectorId: string }> = choice.connectors.map((c, i) => ({
+                    connectorId: c.id,
+                    label: c.id,
+                    description: c.deprecated ? `${c.displayName} — deprecated` : c.displayName,
+                    detail: i === 0 ? 'Suggested best match' : undefined
+                }));
+                const picked = await vscode.window.showQuickPick(items, {
+                    title: `Data connector for "${choice.table}"`,
+                    placeHolder: `"${choice.table}" is provided by ${choice.connectors.length} connectors — choose which one to require`,
+                    matchOnDescription: true
+                });
+                if (!picked) {
+                    vscode.window.showInformationMessage('Populate required data connectors was cancelled.');
+                    return;
+                }
+                connectorId = picked.connectorId;
+            }
+            const tables = byConnector.get(connectorId) ?? [];
+            tables.push(choice.table);
+            byConnector.set(connectorId, tables);
+        }
+
+        // For unknown custom (_CL) tables, offer to register them in .sentinel-connectors.json
+        // inline — the same command-palette style prompt used for multi-connector matches.
+        let registeredCount = 0;
+        for (const table of unmatchedCustomTables) {
+            const defaultId = table.replace(/_CL$/, '');
+            const items: Array<vscode.QuickPickItem & { action: 'add' | 'edit' | 'skip' }> = [
+                { action: 'add', label: `$(add) Add as "${defaultId}"`, detail: `Register a custom connector in .sentinel-connectors.json so "${table}" is required` },
+                { action: 'edit', label: '$(edit) Add with a different connector id…', detail: 'Choose the connectorId to register' },
+                { action: 'skip', label: '$(circle-slash) Skip', detail: 'Leave this table out of requiredDataConnectors' }
+            ];
+            const picked = await vscode.window.showQuickPick(items, {
+                title: `Unknown custom table "${table}"`,
+                placeHolder: `"${table}" isn't provided by any known connector`
+            });
+            if (!picked) {
+                vscode.window.showInformationMessage('Populate required data connectors was cancelled.');
+                return;
+            }
+            if (picked.action === 'skip') {
+                continue;
+            }
+            let connectorId = defaultId;
+            if (picked.action === 'edit') {
+                const input = await vscode.window.showInputBox({
+                    title: `Connector id for "${table}"`,
+                    prompt: 'Written to requiredDataConnectors and .sentinel-connectors.json',
+                    value: defaultId,
+                    validateInput: v => /^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(v.trim()) ? undefined : 'Use letters, numbers, . _ - starting with a letter or number'
+                });
+                if (input === undefined) {
+                    vscode.window.showInformationMessage('Populate required data connectors was cancelled.');
+                    return;
+                }
+                connectorId = input.trim();
+            }
+            const wrote = await this.registerCustomTable(editor.document.uri, connectorId, table);
+            if (wrote) {
+                registeredCount++;
+            } else {
+                vscode.window.showWarningMessage(`Open a workspace folder to save .sentinel-connectors.json; "${table}" was still added to this rule.`);
+            }
+            const customTables = byConnector.get(connectorId) ?? [];
+            if (!customTables.includes(table)) {
+                customTables.push(table);
+            }
+            byConnector.set(connectorId, customTables);
+        }
+
+        if (byConnector.size === 0) {
+            vscode.window.showWarningMessage('No connectors were selected, so requiredDataConnectors was left unchanged.');
+            return;
+        }
+
+        if (registeredCount > 0) {
+            // Refresh so the newly-registered custom tables are recognised for the rest of the session.
+            await ConnectorLoader.loadConnectorData();
+        }
+
+        const connectors = [...byConnector.entries()].map(([connectorId, dataTypes]) => ({ connectorId, dataTypes }));
         parsed.requiredDataConnectors = connectors;
         const reordered = this.reorderToCanonical(parsed);
         const newText = yaml.dump(reordered, { indent: 2, lineWidth: -1, noRefs: true, quotingType: '"', forceQuotes: false });
@@ -106,7 +193,87 @@ export class ContentCommands {
         await editor.edit(editBuilder => editBuilder.replace(fullRange, newText));
 
         const summary = connectors.map(c => `${c.connectorId} (${c.dataTypes.join(', ')})`).join('; ');
-        vscode.window.showInformationMessage(`Populated requiredDataConnectors from the query: ${summary}`);
+        const registeredNote = registeredCount > 0 ? ` (registered ${registeredCount} custom table${registeredCount === 1 ? '' : 's'} in .sentinel-connectors.json)` : '';
+        vscode.window.showInformationMessage(`Populated requiredDataConnectors from the query: ${summary}${registeredNote}`);
+    }
+
+    /**
+     * Registers a custom (_CL) table under a connector in the workspace
+     * .sentinel-connectors.json (creating or merging the file), so future matching and
+     * validation recognise it. Returns the file URI, or undefined when there is no
+     * workspace folder to write to.
+     */
+    private async registerCustomTable(ruleUri: vscode.Uri, connectorId: string, table: string): Promise<vscode.Uri | undefined> {
+        const folder = vscode.workspace.getWorkspaceFolder(ruleUri) ?? vscode.workspace.workspaceFolders?.[0];
+        if (!folder) {
+            return undefined;
+        }
+        const fileUri = vscode.Uri.joinPath(folder.uri, '.sentinel-connectors.json');
+
+        let doc: any = { connectors: [] };
+        try {
+            const existing = await vscode.workspace.fs.readFile(fileUri);
+            const parsedFile = JSON.parse(Buffer.from(existing).toString('utf8'));
+            if (parsedFile && typeof parsedFile === 'object') {
+                doc = parsedFile;
+            }
+        } catch {
+            // No existing file (or unreadable) — start a fresh one.
+        }
+
+        const listKey = Array.isArray(doc.tablesByConnector) ? 'tablesByConnector' : 'connectors';
+        if (!Array.isArray(doc[listKey])) {
+            doc[listKey] = [];
+        }
+        const list: any[] = doc[listKey];
+
+        let entry = list.find(c => (c.connectorId ?? c.id) === connectorId);
+        if (!entry) {
+            // Create a full template so every connector field is present and editable.
+            entry = {
+                connectorId,
+                connectorTitle: connectorId,
+                descriptionMarkdown: '',
+                publisher: 'Custom',
+                source: '',
+                tables: []
+            };
+            list.push(entry);
+        }
+
+        let tables: string[];
+        if (typeof entry.tables === 'string') {
+            tables = entry.tables ? [entry.tables] : [];
+        } else if (Array.isArray(entry.tables)) {
+            tables = entry.tables;
+        } else if (Array.isArray(entry.dataTypes)) {
+            tables = entry.dataTypes;
+        } else {
+            tables = [];
+        }
+        if (!tables.includes(table)) {
+            tables.push(table);
+            tables.sort((a, b) => a.localeCompare(b));
+        }
+        entry.tables = tables;
+
+        // Backfill any missing canonical fields so all options are visible for editing.
+        if (entry.connectorTitle === undefined) {
+            entry.connectorTitle = connectorId;
+        }
+        if (entry.descriptionMarkdown === undefined) {
+            entry.descriptionMarkdown = '';
+        }
+        if (entry.publisher === undefined) {
+            entry.publisher = 'Custom';
+        }
+        if (entry.source === undefined) {
+            entry.source = '';
+        }
+
+        const content = JSON.stringify(doc, null, 2) + '\n';
+        await vscode.workspace.fs.writeFile(fileUri, Buffer.from(content, 'utf8'));
+        return fileUri;
     }
 
     private reorderToCanonical(parsed: Record<string, unknown>): Record<string, unknown> {

--- a/src/utils/validationExclusions.ts
+++ b/src/utils/validationExclusions.ts
@@ -8,11 +8,19 @@ import * as vscode from 'vscode';
 import { matchesAnyGlob } from './globMatcher';
 
 /**
- * True when the document path matches any glob in the
- * sentinelAsCode.validation.excludePatterns setting. Patterns are tested against
- * the workspace-relative path and the absolute path, case-insensitively on Windows.
+ * True when the document should be skipped by the live validators: scaffolding
+ * templates (`*.template.yaml`), which contain {{PLACEHOLDER}} tokens such as
+ * `id: {{GUID}}` and are not deployable rules, plus any path matching a glob in the
+ * sentinelAsCode.validation.excludePatterns setting. Glob patterns are tested
+ * against the workspace-relative path and the absolute path, case-insensitively on
+ * Windows.
  */
 export function isDocumentExcludedFromValidation(document: vscode.TextDocument): boolean {
+    // Scaffolding templates use {{PLACEHOLDER}} tokens and are never live rules.
+    if (/\.template\.ya?ml$/i.test(document.uri.fsPath)) {
+        return true;
+    }
+
     const patterns = vscode.workspace
         .getConfiguration('sentinelAsCode')
         .get<string[]>('validation.excludePatterns', []);

--- a/src/validation/connectorLoader.ts
+++ b/src/validation/connectorLoader.ts
@@ -403,11 +403,46 @@ export class ConnectorLoader {
     }
 
     /**
-     * Extracts the Log Analytics tables referenced by a KQL query (identifiers that
-     * match a known connector table) and maps them to their best-fit data connectors,
-     * grouped as ready-to-use requiredDataConnectors entries.
+     * For each known Log Analytics table referenced by a KQL query, returns the data
+     * connectors that provide it, ranked best-first (non-deprecated and Microsoft
+     * first). Tables appear once, in order of first use. Callers can prompt the user
+     * to choose when a table is provided by more than one connector.
      */
-    public static suggestRequiredDataConnectorsForQuery(query: string): Array<{ connectorId: string; dataTypes: string[] }> {
+    public static getQueryTableConnectorChoices(query: string): Array<{
+        table: string;
+        connectors: Array<{ id: string; displayName: string; deprecated: boolean }>;
+    }> {
+        const index = this.getTableConnectorIndex();
+        const seen = new Set<string>();
+        const choices: Array<{ table: string; connectors: Array<{ id: string; displayName: string; deprecated: boolean }> }> = [];
+
+        const tokenRegex = /[A-Za-z_][A-Za-z0-9_]*/g;
+        let match: RegExpExecArray | null;
+        while ((match = tokenRegex.exec(query)) !== null) {
+            const key = this.normalizeDataType(match[0]);
+            if (!index.has(key) || seen.has(key)) {
+                continue;
+            }
+            seen.add(key);
+            const ranked = this.rankConnectorsForTable(match[0]);
+            if (ranked.length === 0) {
+                continue;
+            }
+            choices.push({
+                table: match[0],
+                connectors: ranked.map(c => ({ id: c.id, displayName: c.displayName, deprecated: !!c.deprecated }))
+            });
+        }
+
+        return choices;
+    }
+
+    /**
+     * Returns the custom (_CL) Log Analytics tables referenced by a KQL query that are
+     * not provided by any known connector, in order of first use. Used to offer
+     * registering them in a workspace .sentinel-connectors.json.
+     */
+    public static getUnmatchedCustomTablesForQuery(query: string): string[] {
         const index = this.getTableConnectorIndex();
         const seen = new Set<string>();
         const tables: string[] = [];
@@ -415,22 +450,33 @@ export class ConnectorLoader {
         const tokenRegex = /[A-Za-z_][A-Za-z0-9_]*/g;
         let match: RegExpExecArray | null;
         while ((match = tokenRegex.exec(query)) !== null) {
-            const key = this.normalizeDataType(match[0]);
-            if (index.has(key) && !seen.has(key)) {
-                seen.add(key);
-                tables.push(match[0]);
-            }
-        }
-
-        const byConnector = new Map<string, string[]>();
-        for (const table of tables) {
-            const ranked = this.rankConnectorsForTable(table);
-            if (ranked.length === 0) {
+            const token = match[0];
+            if (!token.endsWith('_CL')) {
                 continue;
             }
-            const bestConnectorId = ranked[0].id;
+            const key = this.normalizeDataType(token);
+            if (index.has(key) || seen.has(key)) {
+                continue;
+            }
+            seen.add(key);
+            tables.push(token);
+        }
+
+        return tables;
+    }
+
+    /**
+     * Extracts the Log Analytics tables referenced by a KQL query and maps each to its
+     * best-fit data connector (the top-ranked candidate), grouped as ready-to-use
+     * requiredDataConnectors entries. For interactive selection when a table maps to
+     * multiple connectors, use getQueryTableConnectorChoices instead.
+     */
+    public static suggestRequiredDataConnectorsForQuery(query: string): Array<{ connectorId: string; dataTypes: string[] }> {
+        const byConnector = new Map<string, string[]>();
+        for (const choice of this.getQueryTableConnectorChoices(query)) {
+            const bestConnectorId = choice.connectors[0].id;
             const list = byConnector.get(bestConnectorId) ?? [];
-            list.push(table);
+            list.push(choice.table);
             byConnector.set(bestConnectorId, list);
         }
 

--- a/src/validation/validator.ts
+++ b/src/validation/validator.ts
@@ -50,28 +50,6 @@ export class SentinelRuleValidator {
                 return diagnostics;
             }
             
-            // Validate ID field - should be a GUID for Sentinel rules
-            if ('id' in parsedContent) {
-                const id = parsedContent.id?.toString();
-                if (id) {  // Only validate if id exists and is not undefined
-                    const guidPattern = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
-                    if (!guidPattern.test(id)) {
-                        diagnostics.push(new vscode.Diagnostic(
-                            new vscode.Range(0, 0, 0, 0),
-                            `Invalid GUID format for id field: ${id}`,
-                            vscode.DiagnosticSeverity.Error
-                        ));
-                    }
-                } else {
-                    // ID field exists but has no value
-                    diagnostics.push(new vscode.Diagnostic(
-                        new vscode.Range(0, 0, 0, 0),
-                        'ID field exists but has no value',
-                        vscode.DiagnosticSeverity.Error
-                    ));
-                }
-            }
-            
             // Continue with rest of Sentinel validation...
             const lines = content.split('\n');
             


### PR DESCRIPTION
## Summary

Bundles the CI workflow fixes with two authoring improvements to the required-data-connector experience: inline registration of custom `_CL` connectors, and an expanded bundled connector catalogue. Scaffolding templates are also skipped during live validation.

## CI

- `ci: fix release and build workflow failures`
- `ci: bump checkout and setup-node actions to v5`

## Custom data-connector registration (feat)

- **Populate Required Data Connectors from Query** now detects unknown custom (`_CL`) tables in a rule's KQL and offers an inline QuickPick to register each one - accept the derived connector id, enter a different id, or skip.
- New entries are written to a workspace-level `.sentinel-connectors.json` with the full canonical field set (`connectorId`, `connectorTitle`, `descriptionMarkdown`, `publisher`, `source`, `tables`); existing entries are backfilled with any missing fields.
- `connectorLoader.ts` gains `getUnmatchedCustomTablesForQuery()`, returning the distinct unmatched `_CL` tokens in first-seen order.

## Bundled catalogue (feat)

`scripts/extract-connectors.mjs` now emits synthetic platform connectors and table overrides so always-available tables resolve automatically, and `data/connectors.json` is regenerated from it:

- **AzureMonitor** - Heartbeat, LAQueryLogs, Operation, Usage
- **MicrosoftSentinelUEBA** - Anomalies, BehaviorAnalytics, IdentityInfo, UserAccessAnalytics, UserPeerAnalytics
- **Office365** - OfficeActivity override
- **Microsoft Entra ID (AzureActiveDirectory)** - full 15-table set

## Validation (fix)

- Scaffolding templates (`*.template.yaml`, which carry `{{PLACEHOLDER}}` tokens) are now always skipped by the live validators, so they no longer surface diagnostics.
- Removed the hard `id` GUID-format check, which produced false positives on template and in-progress rules; fresh ids are produced by the dedicated rule-id commands.

## Documentation

- `README.md` documents custom `_CL` registration and the `.sentinel-connectors.json` workspace file (new Configuration subsection with a canonical JSON example), plus updated auto-fill bullets, getting-started steps, and command description.

## Testing

- `npm run compile` and `npm run lint:check` both pass with no errors or warnings.
