### PR TITLE
ci: add PR Validation Gate and fix update-data-on-main direct push to protected main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -152,21 +152,12 @@ jobs:
       run: |
         git diff --quiet data/ || echo "changes=true" >> $GITHUB_OUTPUT
 
-    - name: Commit updated data directly to main
-      if: steps.changes.outputs.changes == 'true' && (github.event_name == 'push' && github.ref == 'refs/heads/main')
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add data/
-        git commit -m "chore: update MITRE ATT&CK and Sentinel connector data
-
-        Auto-generated data update including:
-        - MITRE Enterprise, Mobile, and ICS ATT&CK frameworks  
-        - Azure Sentinel connector data from Content Hub
-
-        Updated after merge to main to ensure latest threat intelligence data."
-        git push
-        
+    # A "commit directly to main" step previously ran here on push-to-main, but
+    # main is a protected branch that requires changes to go through a pull
+    # request, so the direct `git push` always failed (GH006: protected branch
+    # update failed). Data refresh now flows exclusively through the
+    # create-pull-request step below (weekly schedule and manual dispatch),
+    # which is compatible with branch protection.
     - name: Create Pull Request with updated data (scheduled/manual runs)
       if: steps.changes.outputs.changes == 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
       uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,8 +7,9 @@ on:
   workflow_dispatch: # Allow manual triggering
   push:
     branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  # Pull-request validation lives in pr-validation.yml (PR Validation Gate).
+  # This workflow is scoped to scheduled/main data refresh only, so it does
+  # not duplicate the per-PR build/test matrix.
 
 # Default permissions for the workflow (most restrictive)
 permissions:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,103 @@
+# ---------------------------------------------------------------------------
+# GitHub Actions Workflow: PR Validation Gate
+# ---------------------------------------------------------------------------
+# Mirrors the "PR Validation Gate" pattern used by the parent
+# Sentinel-As-Code repository, adapted to this TypeScript VS Code extension.
+# The parent repo validates Sentinel *content* (Pester / Bicep / ARM / KQL);
+# this repo instead validates the *extension* — compile, lint, bundle, test,
+# and package — on every pull request.
+#
+# Jobs:
+#   validate        Compile, lint, webpack bundle, VS Code integration tests
+#                   (headless via xvfb), and vsce package, across the
+#                   supported Node.js matrix.
+#   pr-validation   Aggregation gate. Requiring this single context in branch
+#                   protection keeps the required check stable when the Node
+#                   matrix changes (no more stale "build (18.x)"-style gates).
+# ---------------------------------------------------------------------------
+
+name: PR Validation Gate
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch: # Allow manual triggering
+
+# Cancel superseded in-flight runs for the same ref to save CI minutes.
+concurrency:
+  group: pr-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+# Default permissions for the workflow (most restrictive).
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    # Read-only: this job never writes to the repo.
+    permissions:
+      contents: read
+
+    strategy:
+      # Report every matrix leg even if one fails, for clearer signal.
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile TypeScript
+        run: npm run compile
+
+      - name: Build with webpack (for packaging)
+        run: npm run webpack
+
+      - name: Run linter
+        run: npm run lint:check
+
+      - name: Setup virtual display for VS Code tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+
+      - name: Run tests
+        run: xvfb-run -a npm test
+
+      - name: Package extension
+        run: npm run package
+
+  # ---------------------------------------------------------------------------
+  # Aggregation gate
+  # ---------------------------------------------------------------------------
+  # Single, matrix-independent context for branch protection. Succeeds only
+  # when every matrix leg of `validate` succeeds; fails otherwise. Require
+  # THIS check ("pr-validation") in the branch-protection rule rather than the
+  # per-matrix "validate (x.x)" contexts.
+  pr-validation:
+    name: pr-validation
+    runs-on: ubuntu-latest
+    needs: [ validate ]
+    if: always()
+
+    steps:
+      - name: Confirm validation succeeded
+        run: |
+          if [ "${{ needs.validate.result }}" != "success" ]; then
+            echo "::error::PR validation failed (validate result: ${{ needs.validate.result }})."
+            exit 1
+          fi
+          echo "All PR validation checks passed."


### PR DESCRIPTION
## Summary

Two CI workflow changes. PR #54 was merged before the PR Validation Gate was added, so this PR lands the gate on `main` (the branch-protection required check was already re-pointed to it) and fixes a `build.yaml` job that was failing on every merge.

## 1. PR Validation Gate (`pr-validation.yml`)

Modelled on the parent Sentinel-As-Code repo's PR validation, adapted to this TypeScript extension (the parent validates Sentinel content via Pester/Bicep/ARM/KQL, none of which applies here).

- Triggers on `pull_request` (main, develop) and `workflow_dispatch`, with concurrency cancel-in-progress.
- `validate` job (Node 20.x/22.x, `fail-fast: false`): `npm ci`, compile, webpack, `lint:check`, headless VS Code tests via xvfb, and `vsce package` - the same checks `build.yaml` previously ran on PRs.
- `pr-validation` aggregation gate: a single, matrix-independent status context. Branch protection now requires this one context instead of the per-matrix `build (x.x)` contexts, so the required check no longer breaks when the Node matrix changes (the cause of the earlier stuck `build (18.x)` gate).

`build.yaml` also loses its `pull_request` trigger, so the build/test matrix is not duplicated on every PR; it remains responsible for scheduled/main data refresh.

## 2. Fix `update-data-on-main` direct push (`build.yaml`)

The job had a "Commit updated data directly to main" step that ran `git push` straight to `main`. `main` requires changes via a pull request, so the push was rejected on every merge (`GH006: protected branch update failed`) - turning the post-merge run red without updating any data. That step is removed; data refresh now flows only through the existing `peter-evans/create-pull-request` step on the weekly schedule / manual dispatch, which is branch-protection safe.

## Branch protection

Required status check on `main` re-pointed from `build (20.x)` / `build (22.x)` to the single `pr-validation` gate. This PR's head carries `pr-validation.yml`, so the gate runs here and satisfies the requirement.

## Testing

- Both workflows parse as valid YAML exposing the expected jobs.
- `update-data-on-main` retains its download / extract / validate / change-detection / create-pull-request steps; only the direct-push step is removed.
