### PR TITLE
chore(github): modernise Dependabot config (conventional-commit prefixes, drop deprecated reviewers)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,9 +19,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    # Add reviewers and assignees for pull requests
-    reviewers:
-      - "noodlemctwoodle"
     # Group dependency updates to reduce PR noise
     groups:
       # VS Code extension dependencies
@@ -70,8 +67,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    reviewers:
-      - "noodlemctwoodle"
     # Group all GitHub Actions updates together
     groups:
       github-actions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
       time: "09:00"
     # Limit number of open pull requests for npm dependencies
     open-pull-requests-limit: 8
+    # Use conventional-commit prefixes so Dependabot PR titles satisfy the
+    # repository commit convention: chore(deps) for runtime dependencies and
+    # chore(deps-dev) for development dependencies.
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     # Add reviewers and assignees for pull requests
     reviewers:
       - "noodlemctwoodle"
@@ -60,6 +66,10 @@ updates:
       day: "monday"
       time: "10:00"
     open-pull-requests-limit: 3
+    # Conventional-commit prefix for GitHub Actions version bumps: chore(deps).
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     reviewers:
       - "noodlemctwoodle"
     # Group all GitHub Actions updates together


### PR DESCRIPTION
## Summary

Two Dependabot config improvements in `.github/dependabot.yml`:

1. **Conventional-commit prefixes** - add a `commit-message` block (`prefix: "chore"`, `include: "scope"`) to the npm and github-actions ecosystems, so Dependabot PRs land as `chore(deps): ...` / `chore(deps-dev): ...` instead of the default `Bump X from A to B`. This satisfies the conventional-commit convention enforced by the PR template (#56).
2. **Remove the deprecated `reviewers` key** - GitHub has deprecated `reviewers` in `dependabot.yml`; it no longer appears in the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) (which still lists `assignees`) and is ignored by Dependabot. Removed from both ecosystems. To auto-request reviewers on Dependabot PRs, use CODEOWNERS instead.

## Type of change

- [x] chore - repository configuration

## Files changed (high level)

- `.github/dependabot.yml` - add `commit-message` (conventional-commit prefixes) and remove the deprecated `reviewers` blocks for the npm and github-actions ecosystems.

## Testing

- Parsed the file as valid YAML after each change; both ecosystems retain their `commit-message` config and no longer carry `reviewers`.

## Required status check

- `pr-validation` (runs automatically on this PR).
