### PR TITLE
chore(github): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# CODEOWNERS for the Sentinel as Code Toolkit
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Code owners are automatically requested for review on pull requests that
+# change matching files. This is the recommended replacement for the
+# deprecated Dependabot `reviewers` option (see .github/dependabot.yml).
+#
+# Note: "Require review from Code Owners" is not enabled in branch protection,
+# so these entries request review without blocking merges.
+
+# Default owner for everything in the repository.
+* @noodlemctwoodle


### PR DESCRIPTION
## Summary

Adds a `CODEOWNERS` file with a default owner so pull requests automatically request review from the maintainer. This is the recommended replacement for the deprecated Dependabot `reviewers` option removed in #57.

## Type of change

- [x] chore - repository configuration

## Files changed (high level)

- `.github/CODEOWNERS` - default owner `* @noodlemctwoodle`.

## Notes

- Branch protection does not enable "Require review from Code Owners" (`require_code_owner_reviews: false`, `required_approving_review_count: 0`), so this requests review without blocking merges - no deadlock risk for a solo maintainer. If you later enable "Require review from Code Owners", revisit this for single-maintainer workflows.

## Required status check

- `pr-validation` (runs automatically on this PR).
