### PR TITLE
chore(github): pin js-yaml to 4.x in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # js-yaml 5.x is a breaking API rewrite that removed the dump() options this
+      # extension relies on (quotingType, condenseFlow and styles), so it fails to
+      # compile. It is a dual CommonJS/ESM package, so the module format is fine;
+      # the blocker is the API. Stay on 4.x until the dump calls are migrated.
+      - dependency-name: "js-yaml"
+        update-types: ["version-update:semver-major"]
 
   # Enable version updates for GitHub Actions (CI/CD workflows)
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

Adds a `semver-major` ignore for `js-yaml` to the npm ecosystem in `.github/dependabot.yml`, so Dependabot stops re-proposing the breaking 5.x major (#60), which fails CI.

## Why not adopt js-yaml 5.x now

js-yaml 5.0.0 is a breaking API rewrite. It removed the `dump()` options this extension relies on:

- `quotingType` (replaced by `quoteStyle` in 5.1)
- `condenseFlow`
- `styles: { '!!str': 'literal' }` used to force literal block scalars for multiline KQL queries

`load()` also now throws on empty input instead of returning `undefined` (~12 call sites to audit). It is a dual CommonJS/ESM package, so the module format is fine; the blocker is the API. Adopting 5.x is feasible but warrants a dedicated, tested migration (byte-stable output verification), not an auto-merge.

Staying on 4.x is not a security regression: 4.3.0 backported the recent security fixes and the prototype-pollution fix landed in 4.1.1. Dependabot keeps offering 4.x patch and minor updates.

## Testing

- Parsed the updated `dependabot.yml` with js-yaml to confirm valid syntax and that the npm ignore list resolves to `@types/vscode, typescript, js-yaml`.

## Related

- Closes out #60 (js-yaml 5.2.1 major) by pinning to 4.x.
