### PR TITLE
ci(security): pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -160,7 +160,7 @@ jobs:
     # which is compatible with branch protection.
     - name: Create Pull Request with updated data (scheduled/manual runs)
       if: steps.changes.outputs.changes == 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -283,7 +283,7 @@ jobs:
           echo "release-notes-file=release_notes.md" >> $GITHUB_OUTPUT
           
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ needs.check-release.outputs.tag-name }}
           name: "Sentinel as Code Toolkit v${{ needs.check-release.outputs.version }}"


### PR DESCRIPTION
## Summary

Two CodeQL code-scanning alerts ("Unpinned tag for a non-immutable Action in workflow or composite action") flagged the two third-party GitHub Actions used in CI because they were referenced by a mutable major-version tag. A moving tag can be repointed by the upstream owner at any time, so an unreviewed or malicious action version could run in a workflow that holds write permissions. This change pins both actions to immutable commit SHAs, with the corresponding version recorded in a trailing comment.

The GitHub-owned actions/* actions (checkout, setup-node) are immutable and are intentionally left on their version tags.

## Type of change

- [x] ci - workflow / pipeline change

## Files changed (high level)

- .github/workflows/build.yaml - pin peter-evans/create-pull-request from v8 to 5f6978faf089d4d20b00c7766989d076bb2fc7f1 (v8.1.1)
- .github/workflows/release.yaml - pin softprops/action-gh-release from v3 to 718ea10b132b3b2eba29c1007bb80653f286566b (v3.0.1)

## Pre-merge checklist

- [ ] **Compiles** cleanly (`npm run compile`) (not applicable - workflow YAML only)
- [ ] **Lint** passes (`npm run lint:check`) (not applicable - workflow YAML only)
- [ ] **Tests** pass (`npm test`) (run by the PR Validation Gate; unaffected)
- [ ] **Packages** cleanly (`npm run package`) (run by the PR Validation Gate; unaffected)
- [ ] **Schemas / templates** updated if a content type changed (not applicable)
- [ ] **Bundled data** regenerated if the connector source changed (not applicable)
- [x] **No secrets** in committed files (tokens, connection strings, workspace IDs)
- [x] **Commit messages** follow conventional-commit format (`type(scope): subject` plus a detailed body)
- [ ] **Documentation** (README) updated if user-visible behaviour changed (no user-visible behaviour change)

## Testing

- Resolved each SHA from the upstream repository with the GitHub API (`gh api repos/<owner>/<repo>/commits/<major-tag>`), confirming v8 resolves to v8.1.1 and v3 resolves to v3.0.1.
- Scanned all files under .github/workflows and confirmed these two were the only third-party action references; every other reference is a first-party actions/* action on an immutable tag.
- On merge to main, CodeQL re-runs and the two open alerts (build.yaml:163, release.yaml:286) auto-resolve.

## Required status check

- `pr-validation` - runs automatically on this PR

## Related

Resolves the two open CodeQL code-scanning alerts for unpinned third-party action tags.
