### PR TITLE
docs(readme): add centred project logo to the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Sentinel as Code Toolkit
 
+<p align="center">
+  <img src="./images/icon.png" alt="Sentinel-As-Code" width="512" />
+</p>
+
+
+
 ![VS Code](https://img.shields.io/badge/VS%20Code-1.125+-0078D4?logo=visualstudiocode&logoColor=white) ![Version](https://img.shields.io/badge/version-26.07--1-blue) ![License](https://img.shields.io/badge/license-Apache%202.0-green)
 
 **The dedicated VS Code authoring toolkit for the [Sentinel-as-Code](https://github.com/noodlemctwoodle/Sentinel-As-Code) project.**


### PR DESCRIPTION
## Summary

Add the toolkit icon as a centred banner at the top of the README so the project page leads with the Sentinel as Code Toolkit branding. The image references the icon already tracked at images/icon.png, so it renders directly on the GitHub project page. This is a presentation-only change with no effect on the extension or its behaviour.

## Type of change

- [ ] feat - new capability
- [ ] fix - bug fix
- [x] docs - documentation only

## Files changed (high level)

- README.md - insert a centred image block above the badge row, referencing images/icon.png

## Pre-merge checklist

- [ ] **Compiles** cleanly (`npm run compile`) (not applicable - README only)
- [ ] **Lint** passes (`npm run lint:check`) (not applicable - README only)
- [ ] **Tests** pass (`npm test`) (not applicable - README only)
- [ ] **Packages** cleanly (`npm run package`) (not applicable - README only)
- [ ] **Schemas / templates** updated if a content type changed (not applicable)
- [ ] **Bundled data** regenerated if the connector source changed (not applicable)
- [x] **No secrets** in committed files (tokens, connection strings, workspace IDs)
- [x] **Commit messages** follow conventional-commit format (`type(scope): subject` plus a detailed body)
- [x] **Documentation** (README) updated

## Testing

- Confirmed images/icon.png is tracked in the repository, so the referenced image resolves and renders on the GitHub project page.
- Change is limited to the README header markup.

## Required status check

- `pr-validation` - runs automatically on this PR

## Related

Branding polish for the project landing page.
