### PR TITLE
docs(release): remove emojis and repoint links in release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,19 +93,19 @@ jobs:
           # Check for manual trigger first
           if [ "$IS_MANUAL_TRIGGER" = "true" ] && [ "${{ github.event.inputs.force_release }}" = "true" ]; then
             SHOULD_RELEASE="true"
-            echo "✅ Manual release triggered - forcing release creation"
+            echo "Manual release triggered - forcing release creation"
             
             # Check if overwrite is enabled and tag exists
             if [ "${{ github.event.inputs.overwrite_existing }}" = "true" ]; then
               if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-                echo "🔄 Tag $TAG_NAME exists and overwrite is enabled - will recreate"
+                echo "Tag $TAG_NAME exists and overwrite is enabled - will recreate"
               else
-                echo "🆕 Tag $TAG_NAME doesn't exist - will create new"
+                echo "Tag $TAG_NAME doesn't exist - will create new"
               fi
             else
               # Check if tag exists and fail if overwrite is not enabled
               if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-                echo "❌ Tag $TAG_NAME already exists and overwrite is disabled"
+                echo "Tag $TAG_NAME already exists and overwrite is disabled"
                 SHOULD_RELEASE="false"
               fi
             fi
@@ -118,11 +118,11 @@ jobs:
               if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
                 # Check if tag already exists for automatic releases
                 if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-                  echo "❌ Tag $TAG_NAME already exists - skipping automatic release (use manual trigger to overwrite)"
+                  echo "Tag $TAG_NAME already exists - skipping automatic release (use manual trigger to overwrite)"
                   SHOULD_RELEASE="false"
                 else
                   SHOULD_RELEASE="true"
-                  echo "✅ Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION - will create release"
+                  echo "Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION - will create release"
                 fi
               else
                 SHOULD_RELEASE="false"
@@ -131,7 +131,7 @@ jobs:
             else
               # First commit or package.json didn't exist before
               SHOULD_RELEASE="true"
-              echo "✅ Initial version $CURRENT_VERSION - will create release"
+              echo "Initial version $CURRENT_VERSION - will create release"
             fi
           fi
           
@@ -184,23 +184,23 @@ jobs:
         run: |
           TAG_NAME="${{ needs.check-release.outputs.tag-name }}"
           
-          echo "🔄 Manual trigger with overwrite enabled - cleaning up existing release"
+          echo "Manual trigger with overwrite enabled - cleaning up existing release"
           
           # Delete existing release if it exists
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
-            echo "🗑️ Deleting existing release $TAG_NAME"
+            echo "Deleting existing release $TAG_NAME"
             gh release delete "$TAG_NAME" --yes --cleanup-tag
           else
-            echo "ℹ️ No existing release found for $TAG_NAME"
+            echo "No existing release found for $TAG_NAME"
           fi
           
           # Delete existing tag if it exists (both locally and remotely)
           if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            echo "🗑️ Deleting existing tag $TAG_NAME"
+            echo "Deleting existing tag $TAG_NAME"
             git tag -d "$TAG_NAME" 2>/dev/null || true
             git push origin --delete "$TAG_NAME" 2>/dev/null || true
           else
-            echo "ℹ️ No existing tag found for $TAG_NAME"
+            echo "No existing tag found for $TAG_NAME"
           fi
           
           # Wait a moment to ensure GitHub processes the deletion
@@ -216,7 +216,7 @@ jobs:
           TAG_NAME="${{ needs.check-release.outputs.tag-name }}"
           
           # Create new tag
-          echo "🏷️ Creating tag $TAG_NAME"
+          echo "Creating tag $TAG_NAME"
           git tag $TAG_NAME
           git push origin $TAG_NAME
           
@@ -228,20 +228,20 @@ jobs:
           IS_MANUAL="${{ needs.check-release.outputs.is-manual-trigger }}"
           
           if [ "$IS_BETA" = "true" ]; then
-            RELEASE_TYPE="🧪 Beta Release"
-            STABILITY_NOTE="⚠️ **This is a beta release** - Please report any issues via [GitHub Issues](https://github.com/${{ github.repository }}/issues)."
+            RELEASE_TYPE="Beta Release"
+            STABILITY_NOTE="**This is a beta release** - Please report any issues via [GitHub Issues](https://github.com/noodlemctwoodle/Sentinel-As-Code/issues)."
           else
-            RELEASE_TYPE="🚀 Stable Release"
-            STABILITY_NOTE="✅ **Stable release** - Ready for production use."
+            RELEASE_TYPE="Stable Release"
+            STABILITY_NOTE="**Stable release** - Ready for production use."
           fi
           
           # Add manual trigger notice if applicable
           MANUAL_NOTICE=""
           if [ "$IS_MANUAL" = "true" ]; then
             if [ "${{ github.event.inputs.overwrite_existing }}" = "true" ]; then
-              MANUAL_NOTICE="🔄 **This release was manually triggered and overwrote an existing release.**"
+              MANUAL_NOTICE="**This release was manually triggered and overwrote an existing release.**"
             else
-              MANUAL_NOTICE="⚡ **This release was manually triggered.**"
+              MANUAL_NOTICE="**This release was manually triggered.**"
             fi
           fi
           
@@ -252,7 +252,7 @@ jobs:
           
           ${MANUAL_NOTICE}
           
-          ## 📦 Installation
+          ## Installation
           
           ### From VS Code Marketplace
           1. Open VS Code Extensions (Ctrl+Shift+X)
@@ -264,20 +264,18 @@ jobs:
           2. In VS Code: Extensions → "..." → "Install from VSIX"
           3. Select the downloaded file
           
-          ## 🔗 Resources
-          - [Documentation](https://github.com/${{ github.repository }}#readme)
-          - [Report Issues](https://github.com/${{ github.repository }}/issues)
+          ## Resources
+          - [Documentation](https://github.com/noodlemctwoodle/Sentinel-As-Code/tree/main/Docs/Toolkit)
+          - [Report Issues](https://github.com/noodlemctwoodle/Sentinel-As-Code/issues)
           - [Sentinel Blog](https://sentinel.blog)
           
-          ## 📋 What's Included
-          - ✅ Content-based Sentinel rule detection
-          - ✅ Real-time validation with MITRE ATT&CK v16
-          - ✅ Professional formatting and field ordering
-          - ✅ Comprehensive rule templates
-          - ✅ Configurable connector validation
+          ## What's Included
+          - Content-based Sentinel rule detection
+          - Real-time validation with MITRE ATT&CK v16
+          - Professional formatting and field ordering
+          - Comprehensive rule templates
+          - Configurable connector validation
           
-          ---
-          *Built with ❤️ for the Microsoft Sentinel community*
           EOF
           
           echo "release-notes-file=release_notes.md" >> $GITHUB_OUTPUT
@@ -299,13 +297,13 @@ jobs:
           
       - name: Release Summary
         run: |
-          echo "🎉 Successfully created release v${{ needs.check-release.outputs.version }}"
-          echo "🏷️ Tag: ${{ needs.check-release.outputs.tag-name }}"
-          echo "🧪 Beta: ${{ needs.check-release.outputs.is-beta }}"
-          echo "⚡ Manual: ${{ needs.check-release.outputs.is-manual-trigger }}"
-          echo "📦 VSIX: sentinel-as-code-toolkit-${{ needs.check-release.outputs.version }}.vsix"
-          echo "🔗 Release URL: https://github.com/${{ github.repository }}/releases/tag/${{ needs.check-release.outputs.tag-name }}"
+          echo "Successfully created release v${{ needs.check-release.outputs.version }}"
+          echo "Tag: ${{ needs.check-release.outputs.tag-name }}"
+          echo "Beta: ${{ needs.check-release.outputs.is-beta }}"
+          echo "Manual: ${{ needs.check-release.outputs.is-manual-trigger }}"
+          echo "VSIX: sentinel-as-code-toolkit-${{ needs.check-release.outputs.version }}.vsix"
+          echo "Release URL: https://github.com/${{ github.repository }}/releases/tag/${{ needs.check-release.outputs.tag-name }}"
           
           if [ "${{ needs.check-release.outputs.is-manual-trigger }}" = "true" ] && [ "${{ github.event.inputs.overwrite_existing }}" = "true" ]; then
-            echo "🔄 This was a manual overwrite of an existing release"
+            echo "This was a manual overwrite of an existing release"
           fi


### PR DESCRIPTION
## Summary

Clean up the automated release notes produced by the release workflow so the published GitHub release page matches the project conventions. The three problems visible on the v26.7.1 release page are fixed at source: the notes were full of emojis, they carried a "Built with ... community" tagline that predates the Apache-2.0 relicense, and the Documentation and Report Issues links pointed at the toolkit repository instead of the parent Sentinel-As-Code project.

- Remove every emoji from the generated release notes and from the workflow log output.
- Repoint Documentation to the canonical Docs/Toolkit reference and Report Issues to the shared issue tracker in the parent Sentinel-As-Code repository, matching the README.
- Remove the "Built with ... for the Microsoft Sentinel community" tagline.

Note: this corrects the template so every future release is clean. The already-published v26.7.1 release body is a static artifact and needs a separate one-off edit if you want it cleaned retroactively.

## Type of change

- [x] docs - documentation only
- [x] ci - workflow / pipeline change

## Files changed (high level)

- .github/workflows/release.yaml - clean the "Generate release notes" heredoc (headings, resource links, What's Included bullets, and the beta and manual notices) and strip emojis from the check-release, delete, tag, and summary log echoes

## Pre-merge checklist

- [ ] **Compiles** cleanly (`npm run compile`) (not applicable - workflow YAML only)
- [ ] **Lint** passes (`npm run lint:check`) (not applicable - workflow YAML only)
- [ ] **Tests** pass (`npm test`) (run by the PR Validation Gate; unaffected)
- [ ] **Packages** cleanly (`npm run package`) (run by the PR Validation Gate; unaffected)
- [ ] **Schemas / templates** updated if a content type changed (not applicable)
- [ ] **Bundled data** regenerated if the connector source changed (not applicable)
- [x] **No secrets** in committed files (tokens, connection strings, workspace IDs)
- [x] **Commit messages** follow conventional-commit format (`type(scope): subject` plus a detailed body)
- [ ] **Documentation** (README) updated if user-visible behaviour changed (release notes only)

## Testing

- Parsed the workflow with js-yaml to confirm it is still valid.
- Scanned the file for non-ASCII characters; only the intentional typographic arrows in the install instructions remain.
- Confirmed Documentation and Report Issues now resolve to github.com/noodlemctwoodle/Sentinel-As-Code, matching the README.

## Required status check

- `pr-validation` - runs automatically on this PR

## Related

Addresses the emoji, tagline, and misdirected-link issues seen on the v26.7.1 release page.
