### PR TITLE
chore(release): bump version to 26.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 
-![VS Code](https://img.shields.io/badge/VS%20Code-1.125+-0078D4?logo=visualstudiocode&logoColor=white) ![Version](https://img.shields.io/badge/version-26.07--1-blue) ![License](https://img.shields.io/badge/license-Apache%202.0-green)
+![VS Code](https://img.shields.io/badge/VS%20Code-1.125+-0078D4?logo=visualstudiocode&logoColor=white) ![Version](https://img.shields.io/badge/version-26.07--2-blue) ![License](https://img.shields.io/badge/license-Apache%202.0-green)
 
 **The dedicated VS Code authoring toolkit for the [Sentinel-as-Code](https://github.com/noodlemctwoodle/Sentinel-As-Code) project.**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sentinelcodeguard",
-  "version": "26.7.1",
+  "version": "26.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sentinelcodeguard",
-      "version": "26.7.1",
+      "version": "26.7.2",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sentinelcodeguard",
   "displayName": "Sentinel as Code Toolkit",
   "description": "The dedicated VS Code toolkit for the Sentinel-as-Code project: intelligent validation, formatting, templates, and ARM-to-YAML conversion for Microsoft Sentinel Analytics Rules",
-  "version": "26.7.1",
+  "version": "26.7.2",
   "publisher": "noodlemctwoodle",
   "icon": "images/icon.png",
   "engines": {


### PR DESCRIPTION
## Summary

Bump the extension version to 26.7.2 to cut the next release.

Follow-up to #68 (Marketplace icon fix + beta-flag removal), already merged to main. That PR did not carry the version bump, so this PR adds it on its own.

## Changes

- package.json / package-lock.json: version 26.7.2.
- README.md: version badge updated to 26.07-2 (zero-padded display form).

## Release impact

Merging this changes package.json on main, which triggers the release workflow to publish v26.7.2 as a stable release (prerelease: false, make_latest: true) — the first release under the beta-removed workflow.