### PR TITLE
feat(mitre): MITRE IntelliSense and hover across all content types (26.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to the Sentinel as Code Toolkit are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Releases prior to 26.7.2 are listed on the
+[GitHub Releases](https://github.com/noodlemctwoodle/Sentinel-As-Code-Toolkit/releases) page.
+
+## [26.7.3] - 2026-07-10
+
+### Added
+
+- MITRE ATT&CK IntelliSense and hover now work across every content type that
+  carries MITRE metadata: analytics rules and NRT rules (`relevantTechniques`),
+  hunting queries (`techniques`), and Defender custom detections
+  (`mitreTechniques`), plus files opened under the custom `sentinel-rule`
+  language (`.sentinel.yaml` / `.sentinel.yml`).
+
+### Fixed
+
+- Technique completion now recognises the `relevantTechniques` and
+  `mitreTechniques` fields (previously only `techniques` matched) and no longer
+  stops after the first 50 techniques, so all techniques and sub-techniques are
+  suggested.
+- Analytics-rule validation and hunting-query diagnostics now run on
+  `.sentinel.yaml` files (the `sentinel-rule` language), matching the behaviour
+  of plain `.yaml` files.
+
+## [26.7.2] - 2026-07-10
+
+### Fixed
+
+- The extension icon no longer appears broken on the Visual Studio Marketplace
+  listing (corrected the `repository` URL and used an absolute README image URL).
+
+### Changed
+
+- Releases now publish as stable by default; removed the automatic beta flagging
+  from the release workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ Releases prior to 26.7.2 are listed on the
   hunting queries (`techniques`), and Defender custom detections
   (`mitreTechniques`), plus files opened under the custom `sentinel-rule`
   language (`.sentinel.yaml` / `.sentinel.yml`).
+- New **Convert Content JSON to YAML** command
+  (`sentinelAsCode.convertContentToYaml`) — the inverse of **Convert Content
+  YAML to JSON**. Converts a summary rule, automation rule, or watchlist
+  authored in JSON to readable YAML next to the source file. Available from the
+  command palette and the editor/explorer right-click menus on `.json` files.
+- Value IntelliSense now covers `severity` and the ISO 8601 duration fields
+  `queryFrequency`, `queryPeriod`, and `suppressionDuration`. Severity is
+  content-type aware (capitalised `High`/`Medium`/`Low`/`Informational` for
+  Sentinel rules, lowercase for Defender custom detections), and the duration
+  fields suggest common values with human-readable labels (for example `PT5H`
+  shown as 5 hours); `suppressionDuration` is capped at 24 hours.
+
+### Changed
+
+- Streamlined the command palette to a single **New Sentinel-as-Code
+  Content...** entry for scaffolding. The overlapping **Generate Rule Template**
+  picker and the individual **New Hunting Query**, **New Parser**, **New Summary
+  Rule**, **New Automation Rule**, and **Generate Custom Detection Template**
+  entries are now hidden from the palette; the commands remain registered so
+  **New Sentinel-as-Code Content...**, context menus, and keybindings keep
+  working.
 
 ### Fixed
 
@@ -25,6 +46,9 @@ Releases prior to 26.7.2 are listed on the
 - Analytics-rule validation and hunting-query diagnostics now run on
   `.sentinel.yaml` files (the `sentinel-rule` language), matching the behaviour
   of plain `.yaml` files.
+- The scaffolded default `severity` is now `Medium` (was incorrectly `Low` due
+  to an off-by-one index into `VALID_SEVERITIES`), matching the documented
+  intent and the ARM-to-YAML converter's fallback.
 
 ## [26.7.2] - 2026-07-10
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 
-![VS Code](https://img.shields.io/badge/VS%20Code-1.125+-0078D4?logo=visualstudiocode&logoColor=white) ![Version](https://img.shields.io/badge/version-26.07--2-blue) ![License](https://img.shields.io/badge/license-Apache%202.0-green)
+![VS Code](https://img.shields.io/badge/VS%20Code-1.125+-0078D4?logo=visualstudiocode&logoColor=white) ![Version](https://img.shields.io/badge/version-26.07--3-blue) ![License](https://img.shields.io/badge/license-Apache%202.0-green)
 
 **The dedicated VS Code authoring toolkit for the [Sentinel-as-Code](https://github.com/noodlemctwoodle/Sentinel-As-Code) project.**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sentinelcodeguard",
-  "version": "26.7.2",
+  "version": "26.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sentinelcodeguard",
-      "version": "26.7.2",
+      "version": "26.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,11 @@
         "category": "Sentinel-As-Code"
       },
       {
+        "command": "sentinelAsCode.convertContentToYaml",
+        "title": "Convert Content JSON to YAML",
+        "category": "Sentinel-As-Code"
+      },
+      {
         "command": "defender.formatForRepo",
         "title": "Format Custom Detection for Repo",
         "category": "Defender-As-Code"
@@ -245,6 +250,11 @@
           "when": "resourceExtname == .yaml || resourceExtname == .yml",
           "command": "sentinelAsCode.convertContentToJson",
           "group": "sentinel@8"
+        },
+        {
+          "when": "resourceExtname == .json",
+          "command": "sentinelAsCode.convertContentToYaml",
+          "group": "sentinel@9"
         }
       ],
       "explorer/context": [
@@ -267,6 +277,11 @@
           "when": "resourceExtname == .yaml || resourceExtname == .yml",
           "command": "sentinelAsCode.convertContentToJson",
           "group": "sentinel@4"
+        },
+        {
+          "when": "resourceExtname == .json",
+          "command": "sentinelAsCode.convertContentToYaml",
+          "group": "sentinel@5"
         }
       ],
       "commandPalette": [
@@ -279,7 +294,8 @@
           "when": "false"
         },
         {
-          "command": "sentinelAsCode.generateRuleTemplate"
+          "command": "sentinelAsCode.generateRuleTemplate",
+          "when": "false"
         },
         {
           "command": "sentinelAsCode.regenerateGuid",
@@ -307,6 +323,9 @@
           "command": "sentinelAsCode.convertContentToJson"
         },
         {
+          "command": "sentinelAsCode.convertContentToYaml"
+        },
+        {
           "command": "sentinelAsCode.generateTemplate",
           "when": "false"
         },
@@ -315,7 +334,8 @@
           "when": "false"
         },
         {
-          "command": "defender.generateDetectionTemplate"
+          "command": "defender.generateDetectionTemplate",
+          "when": "false"
         },
         {
           "command": "sentinelAsCode.createWatchlistFromCsv",
@@ -325,16 +345,20 @@
           "command": "sentinelAsCode.newContent"
         },
         {
-          "command": "sentinelAsCode.createHuntingQuery"
+          "command": "sentinelAsCode.createHuntingQuery",
+          "when": "false"
         },
         {
-          "command": "sentinelAsCode.createParser"
+          "command": "sentinelAsCode.createParser",
+          "when": "false"
         },
         {
-          "command": "sentinelAsCode.createSummaryRule"
+          "command": "sentinelAsCode.createSummaryRule",
+          "when": "false"
         },
         {
-          "command": "sentinelAsCode.createAutomationRule"
+          "command": "sentinelAsCode.createAutomationRule",
+          "when": "false"
         },
         {
           "command": "sentinelAsCode.populateDataConnectors",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sentinelcodeguard",
   "displayName": "Sentinel as Code Toolkit",
   "description": "The dedicated VS Code toolkit for the Sentinel-as-Code project: intelligent validation, formatting, templates, and ARM-to-YAML conversion for Microsoft Sentinel Analytics Rules",
-  "version": "26.7.2",
+  "version": "26.7.3",
   "publisher": "noodlemctwoodle",
   "icon": "images/icon.png",
   "engines": {

--- a/src/commands/content/contentCommands.ts
+++ b/src/commands/content/contentCommands.ts
@@ -31,7 +31,8 @@ export class ContentCommands {
             vscode.commands.registerCommand('sentinelAsCode.createAutomationRule', () => ContentBuilders.createAutomationRule()),
             vscode.commands.registerCommand('sentinelAsCode.createWatchlistFromCsv', () => WatchlistBuilder.createFromActiveCsv()),
             vscode.commands.registerCommand('sentinelAsCode.populateDataConnectors', () => this.populateDataConnectors()),
-            vscode.commands.registerCommand('sentinelAsCode.convertContentToJson', (uri?: vscode.Uri) => this.convertContentToJson(uri))
+            vscode.commands.registerCommand('sentinelAsCode.convertContentToJson', (uri?: vscode.Uri) => this.convertContentToJson(uri)),
+            vscode.commands.registerCommand('sentinelAsCode.convertContentToYaml', (uri?: vscode.Uri) => this.convertContentToYaml(uri))
         ];
     }
 
@@ -180,6 +181,74 @@ export class ContentCommands {
         const jsonDoc = await vscode.workspace.openTextDocument(targetUri);
         await vscode.window.showTextDocument(jsonDoc, { preview: false });
         vscode.window.showInformationMessage(`Converted to JSON: ${path.basename(targetUri.fsPath)}`);
+    }
+
+    /**
+     * Converts the active (or right-clicked) Sentinel content JSON file to YAML,
+     * writing <name>.yaml next to it. The inverse of convertContentToJson, used to
+     * re-author a summary rule, automation rule, or watchlist as readable YAML
+     * from its JSON form.
+     */
+    private async convertContentToYaml(uri?: vscode.Uri): Promise<void> {
+        let doc: vscode.TextDocument;
+        try {
+            if (uri && uri.fsPath) {
+                doc = await vscode.workspace.openTextDocument(uri);
+            } else if (vscode.window.activeTextEditor) {
+                doc = vscode.window.activeTextEditor.document;
+            } else {
+                vscode.window.showErrorMessage('Open a Sentinel content JSON file to convert to YAML.');
+                return;
+            }
+        } catch (error) {
+            vscode.window.showErrorMessage(`Could not open the file: ${error instanceof Error ? error.message : 'unknown error'}`);
+            return;
+        }
+
+        if (doc.languageId !== 'json' && !/\.json$/i.test(doc.uri.fsPath)) {
+            vscode.window.showErrorMessage('The active file is not JSON. Open the JSON content you want to convert to YAML.');
+            return;
+        }
+
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(doc.getText());
+        } catch (error) {
+            vscode.window.showErrorMessage(`Could not parse the JSON: ${error instanceof Error ? error.message : 'invalid JSON'}`);
+            return;
+        }
+        if (!parsed || typeof parsed !== 'object') {
+            vscode.window.showErrorMessage('The JSON did not parse to an object, so there is nothing to convert.');
+            return;
+        }
+
+        const yamlText = yaml.dump(parsed, { indent: 2, lineWidth: -1, noRefs: true, quotingType: '"', forceQuotes: false });
+
+        let targetUri: vscode.Uri | undefined;
+        if (doc.uri.scheme === 'file') {
+            const dir = path.dirname(doc.uri.fsPath);
+            const base = path.basename(doc.uri.fsPath).replace(/\.json$/i, '');
+            targetUri = vscode.Uri.file(path.join(dir, `${base}.yaml`));
+        } else {
+            targetUri = await vscode.window.showSaveDialog({
+                filters: { 'YAML Files': ['yaml', 'yml'], 'All Files': ['*'] },
+                title: 'Save converted YAML'
+            });
+        }
+        if (!targetUri) {
+            return;
+        }
+
+        try {
+            await vscode.workspace.fs.writeFile(targetUri, Buffer.from(yamlText, 'utf8'));
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to write YAML: ${error instanceof Error ? error.message : 'unknown error'}`);
+            return;
+        }
+
+        const yamlDoc = await vscode.workspace.openTextDocument(targetUri);
+        await vscode.window.showTextDocument(yamlDoc, { preview: false });
+        vscode.window.showInformationMessage(`Converted to YAML: ${path.basename(targetUri.fsPath)}`);
     }
 
     private async populateDataConnectors(): Promise<void> {

--- a/src/content/contentDiagnostics.ts
+++ b/src/content/contentDiagnostics.ts
@@ -36,7 +36,7 @@ export class ContentDiagnosticsManager {
     }
 
     private update(document: vscode.TextDocument): void {
-        if (document.languageId !== 'yaml') {
+        if (document.languageId !== 'yaml' && document.languageId !== 'sentinel-rule') {
             this.collection.delete(document.uri);
             return;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,15 +63,23 @@ export async function activate(context: vscode.ExtensionContext) {
         const formatterProvider = createFormattingProvider();
         console.log('🎨 Sentinel as Code Toolkit: Registered formatting provider');
 
-        const completionProvider = vscode.languages.registerCompletionItemProvider(
+        // Sentinel-as-Code YAML content is served either as plain YAML or under
+        // the custom `sentinel-rule` language (bound to *.sentinel.yaml). Register
+        // language services for both so MITRE IntelliSense/hover works regardless.
+        const sentinelYamlSelector: vscode.DocumentSelector = [
             { scheme: 'file', language: 'yaml' },
+            { scheme: 'file', language: 'sentinel-rule' }
+        ];
+
+        const completionProvider = vscode.languages.registerCompletionItemProvider(
+            sentinelYamlSelector,
             new SentinelCompletionProvider(),
             ':', '"', "'", '-', ' '  // Trigger characters ('- ' opens the table list)
         );
         
         // Register hover provider for MITRE techniques and tactics
         const hoverProvider = vscode.languages.registerHoverProvider(
-            { scheme: 'file', language: 'yaml' },
+            sentinelYamlSelector,
             new SentinelRuleHoverProvider()
         );
         

--- a/src/formatting/formatter.ts
+++ b/src/formatting/formatter.ts
@@ -16,7 +16,7 @@ export class SentinelRuleFormatter {
         'id': () => uuidv4(),
         'name': () => 'New Detection Rule',
         'description': () => 'Enter rule description here',
-        'severity': () => VALID_SEVERITIES[1], // Medium
+        'severity': () => VALID_SEVERITIES[2], // Medium
         'requiredDataConnectors': () => [{
             connectorId: 'YourConnectorId',
             dataTypes: ['YourDataType']

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ConnectorLoader } from '../validation/connectorLoader';
-import { MitreLoader } from '../validation/mitreLoader';
+import { MitreLoader, MITRE_TACTIC_FIELDS, MITRE_TECHNIQUE_FIELDS } from '../validation/mitreLoader';
 
 // Export the interfaces so they can be used by the completion provider
 export interface MitreTactic {
@@ -120,56 +120,50 @@ export class SentinelCompletionProvider implements vscode.CompletionItemProvider
     }
     
     private isTacticsContext(document: vscode.TextDocument, position: vscode.Position): boolean {
-        const lineText = document.lineAt(position).text;
-        
-        // Direct line detection
-        if (lineText.includes('tactics:') || lineText.includes('tactics')) {
-            return true;
-        }
-        
-        // Array item detection
-        if (lineText.trim().startsWith('-') && this.isInSection(document, position, 'tactics')) {
-            return true;
-        }
-        
-        return false;
+        return this.isInMitreSection(document, position, MITRE_TACTIC_FIELDS);
     }
     
     private isTechniquesContext(document: vscode.TextDocument, position: vscode.Position): boolean {
-        const lineText = document.lineAt(position).text;
-        
-        // Direct line detection
-        if (lineText.includes('techniques:') || lineText.includes('techniques')) {
-            return true;
-        }
-        
-        // Array item detection
-        if (lineText.trim().startsWith('-') && this.isInSection(document, position, 'techniques')) {
-            return true;
-        }
-        
-        // Value position detection (after colon)
-        const beforeCursor = lineText.substring(0, position.character);
-        if (beforeCursor.includes('techniques:')) {
-            return true;
-        }
-        
-        return false;
+        return this.isInMitreSection(document, position, MITRE_TECHNIQUE_FIELDS);
     }
     
-    private isInSection(document: vscode.TextDocument, position: vscode.Position, sectionName: string): boolean {
-        // Look backwards to find the section header
-        for (let i = position.line; i >= Math.max(0, position.line - 20); i--) {
-            const line = document.lineAt(i).text;
-            
-            // Found our section
-            if (line.includes(`${sectionName}:`)) {
-                return true;
+    // Determines whether the cursor sits inside a MITRE list governed by one of
+    // the given field keys. Matching is anchored to the YAML key (start-of-key,
+    // case-sensitive) so `relevantTechniques` and `techniques` are told apart and
+    // the word never matches inside a description or comment.
+    private isInMitreSection(document: vscode.TextDocument, position: vscode.Position, keys: string[]): boolean {
+        const line = document.lineAt(position.line).text;
+
+        // On the field's own key line (e.g. "tactics:" or "relevantTechniques:"),
+        // including when the cursor sits in the inline value position.
+        const keyOnLine = /^\s*([A-Za-z0-9_]+):/.exec(line);
+        if (keyOnLine && keys.includes(keyOnLine[1])) {
+            return true;
+        }
+
+        // On a block-sequence item ("- value") or a blank/partial line where the
+        // user is about to add one: walk up to the governing mapping key.
+        const beforeCursor = line.slice(0, position.character);
+        const onListItem = /^\s*-\s*/.test(line);
+        const onBlankOrPartial = /^\s*[A-Za-z0-9_.]*$/.test(beforeCursor);
+        if (!onListItem && !onBlankOrPartial) {
+            return false;
+        }
+
+        for (let i = position.line - 1; i >= 0 && i >= position.line - 20; i--) {
+            const above = document.lineAt(i).text;
+            if (above.trim() === '') {
+                continue;
             }
-            
-            // Found a different top-level section (stop searching)
-            if (line.trim() && !line.startsWith(' ') && !line.startsWith('-') && line.includes(':') && !line.includes(`${sectionName}:`)) {
-                break;
+            const keyMatch = /^(\s*)([A-Za-z0-9_]+):/.exec(above);
+            if (keyMatch) {
+                if (keys.includes(keyMatch[2])) {
+                    return true;
+                }
+                // A top-level key that isn't ours ends this block.
+                if (keyMatch[1].length === 0) {
+                    return false;
+                }
             }
         }
         return false;
@@ -271,7 +265,7 @@ export class SentinelCompletionProvider implements vscode.CompletionItemProvider
             const techniquesData = (MitreLoader as any).getAllTechniques?.();
             if (techniquesData && Array.isArray(techniquesData)) {
                 console.log(`Found ${techniquesData.length} techniques with details`);
-                return techniquesData.slice(0, 50).map((technique: MitreTechnique) => { // Limit to 50 for performance
+                return techniquesData.map((technique: MitreTechnique) => {
                     const item = new vscode.CompletionItem(technique.id, vscode.CompletionItemKind.EnumMember);
                     item.detail = `${technique.name} (${technique.tactics.join(', ')})`;
                     

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import { ConnectorLoader } from '../validation/connectorLoader';
 import { MitreLoader, MITRE_TACTIC_FIELDS, MITRE_TECHNIQUE_FIELDS } from '../validation/mitreLoader';
+import { RuleTypeDetector, RuleType } from '../utils/ruleTypeDetector';
+import { VALID_SEVERITIES } from '../validation/constants';
 
 // Export the interfaces so they can be used by the completion provider
 export interface MitreTactic {
@@ -47,6 +49,15 @@ export class SentinelCompletionProvider implements vscode.CompletionItemProvider
 
         if (this.isTechniquesContext(document, position)) {
             return this.getTechniquesCompletions();
+        }
+
+        if (this.isSeverityContext(document, position)) {
+            return this.getSeverityCompletions(document, wordRange);
+        }
+
+        const durationField = this.getDurationField(document, position);
+        if (durationField) {
+            return this.getDurationCompletions(durationField, wordRange);
         }
 
         return [];
@@ -306,5 +317,111 @@ export class SentinelCompletionProvider implements vscode.CompletionItemProvider
             item.sortText = `technique_${technique}`;
             return item;
         });
+    }
+
+    // Human-readable notes per severity level, keyed by the canonical capitalised
+    // form. Defender custom detections reuse these with lowercase values.
+    private static readonly SEVERITY_DESCRIPTIONS: Record<string, string> = {
+        High: 'Highest priority. Significant or immediate threat.',
+        Medium: 'Notable activity that should be reviewed.',
+        Low: 'Lower-priority signal, often benign.',
+        Informational: 'No direct impact; contextual awareness only.'
+    };
+
+    // Common ISO 8601 durations with human-readable labels, ordered shortest to
+    // longest so the completion list reads naturally.
+    private static readonly DURATION_OPTIONS: { value: string; label: string; minutes: number }[] = [
+        { value: 'PT5M', label: '5 minutes', minutes: 5 },
+        { value: 'PT10M', label: '10 minutes', minutes: 10 },
+        { value: 'PT15M', label: '15 minutes', minutes: 15 },
+        { value: 'PT30M', label: '30 minutes', minutes: 30 },
+        { value: 'PT1H', label: '1 hour', minutes: 60 },
+        { value: 'PT2H', label: '2 hours', minutes: 120 },
+        { value: 'PT3H', label: '3 hours', minutes: 180 },
+        { value: 'PT4H', label: '4 hours', minutes: 240 },
+        { value: 'PT5H', label: '5 hours', minutes: 300 },
+        { value: 'PT6H', label: '6 hours', minutes: 360 },
+        { value: 'PT8H', label: '8 hours', minutes: 480 },
+        { value: 'PT12H', label: '12 hours', minutes: 720 },
+        { value: 'PT24H', label: '24 hours', minutes: 1440 },
+        { value: 'P1D', label: '1 day', minutes: 1440 },
+        { value: 'P2D', label: '2 days', minutes: 2880 },
+        { value: 'P3D', label: '3 days', minutes: 4320 },
+        { value: 'P7D', label: '7 days', minutes: 10080 },
+        { value: 'P14D', label: '14 days', minutes: 20160 }
+    ];
+
+    private isSeverityContext(document: vscode.TextDocument, position: vscode.Position): boolean {
+        return this.isScalarValueContext(document, position, ['severity']);
+    }
+
+    // Sentinel analytics/NRT rules use capitalised severities; Defender custom
+    // detections use the lowercase form. Detect the rule type so the suggested
+    // casing is always valid for the file being edited.
+    private getSeverityCompletions(document: vscode.TextDocument, range?: vscode.Range): vscode.CompletionItem[] {
+        const isDefender = RuleTypeDetector.detectType(document.getText()) === RuleType.DEFENDER;
+        // VALID_SEVERITIES is ordered Informational -> High; present most severe first.
+        const ordered = [...VALID_SEVERITIES].reverse();
+        return ordered.map((severity, index) => {
+            const value = isDefender ? severity.toLowerCase() : severity;
+            const item = new vscode.CompletionItem(value, vscode.CompletionItemKind.EnumMember);
+            item.detail = isDefender ? 'Defender custom detection severity' : 'Sentinel rule severity';
+            const description = SentinelCompletionProvider.SEVERITY_DESCRIPTIONS[severity];
+            if (description) {
+                item.documentation = new vscode.MarkdownString(`**${value}** — ${description}`);
+            }
+            item.insertText = value;
+            if (range) {
+                item.range = range;
+            }
+            item.sortText = `severity_${index}`;
+            item.filterText = value;
+            return item;
+        });
+    }
+
+    private getDurationField(document: vscode.TextDocument, position: vscode.Position): 'schedule' | 'suppression' | undefined {
+        if (this.isScalarValueContext(document, position, ['queryFrequency', 'queryPeriod'])) {
+            return 'schedule';
+        }
+        if (this.isScalarValueContext(document, position, ['suppressionDuration'])) {
+            return 'suppression';
+        }
+        return undefined;
+    }
+
+    // Scheduled cadence fields accept 5 minutes to 14 days; suppressionDuration is
+    // capped at 24 hours, so the longer options are filtered out for it.
+    private getDurationCompletions(field: 'schedule' | 'suppression', range?: vscode.Range): vscode.CompletionItem[] {
+        const maxMinutes = field === 'suppression' ? 1440 : Number.MAX_SAFE_INTEGER;
+        return SentinelCompletionProvider.DURATION_OPTIONS
+            .filter(option => option.minutes <= maxMinutes)
+            .map((option, index) => {
+                const item = new vscode.CompletionItem(
+                    { label: option.value, description: option.label },
+                    vscode.CompletionItemKind.Value
+                );
+                item.detail = option.label;
+                item.documentation = new vscode.MarkdownString(`\`${option.value}\` — ${option.label} (ISO 8601 duration)`);
+                item.insertText = option.value;
+                if (range) {
+                    item.range = range;
+                }
+                item.sortText = `duration_${String(index).padStart(2, '0')}`;
+                item.filterText = `${option.value} ${option.label}`;
+                return item;
+            });
+    }
+
+    // A scalar (inline) value context: the cursor sits in the value position of a
+    // "<key>: <value>" line for one of the given keys. Used for single-value fields
+    // (severity, durations) rather than the block-sequence lists above.
+    private isScalarValueContext(document: vscode.TextDocument, position: vscode.Position, keys: string[]): boolean {
+        const line = document.lineAt(position.line).text;
+        const match = /^\s*([A-Za-z0-9_]+):\s*/.exec(line);
+        if (!match || !keys.includes(match[1])) {
+            return false;
+        }
+        return position.character >= match[0].length;
     }
 }

--- a/src/providers/hoverProvider.ts
+++ b/src/providers/hoverProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { MitreLoader } from '../validation/mitreLoader';
+import { MitreLoader, MITRE_TACTIC_FIELDS, MITRE_TECHNIQUE_FIELDS } from '../validation/mitreLoader';
 import { ConnectorLoader } from '../validation/connectorLoader';
 
 export class SentinelRuleHoverProvider implements vscode.HoverProvider {
@@ -48,23 +48,26 @@ export class SentinelRuleHoverProvider implements vscode.HoverProvider {
      * Determines if the current position is within a MITRE-related YAML section
      * Returns 'tactics', 'techniques', or null
      */
-    private getMitreContext(document: vscode.TextDocument, position: vscode.Position): string | null {
-        // Look backwards from current position to find the relevant YAML section
-        for (let i = position.line; i >= 0; i--) {
-            const line = document.lineAt(i).text;
-            const trimmedLine = line.trim();
-            
-            // If we hit another top-level field (not indented), we're outside the MITRE context
-            if (i < position.line && /^[a-zA-Z]/.test(trimmedLine) && !trimmedLine.startsWith('tactics:') && !trimmedLine.startsWith('techniques:')) {
-                break;
+    private getMitreContext(document: vscode.TextDocument, position: vscode.Position): 'tactics' | 'techniques' | null {
+        // Walk up to the nearest governing YAML key. Matching is anchored to the
+        // key name so tactic-name hovers fire for `tactics`, while every
+        // technique-list field (relevantTechniques / techniques / mitreTechniques)
+        // is recognised regardless of content type.
+        for (let i = position.line; i >= 0 && i >= position.line - 20; i--) {
+            const keyMatch = /^(\s*)([A-Za-z0-9_]+):/.exec(document.lineAt(i).text);
+            if (!keyMatch) {
+                continue;
             }
-            
-            // Check for MITRE section headers
-            if (trimmedLine === 'tactics:' || trimmedLine.startsWith('tactics:')) {
+            const key = keyMatch[2];
+            if (MITRE_TACTIC_FIELDS.includes(key)) {
                 return 'tactics';
             }
-            if (trimmedLine === 'techniques:' || trimmedLine.startsWith('techniques:')) {
+            if (MITRE_TECHNIQUE_FIELDS.includes(key)) {
                 return 'techniques';
+            }
+            // A different top-level key means we've left the MITRE block.
+            if (keyMatch[1].length === 0) {
+                return null;
             }
         }
         

--- a/src/validation/mitreLoader.ts
+++ b/src/validation/mitreLoader.ts
@@ -1,6 +1,15 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 
+/**
+ * MITRE ATT&CK metadata field names as they appear across the Sentinel-as-Code
+ * content types. `tactics` is shared; the technique-list key differs by type:
+ * analytics rules use `relevantTechniques`, hunting queries use `techniques`,
+ * and Defender custom detections use `mitreTechniques`.
+ */
+export const MITRE_TACTIC_FIELDS: string[] = ['tactics'];
+export const MITRE_TECHNIQUE_FIELDS: string[] = ['relevantTechniques', 'techniques', 'mitreTechniques'];
+
 interface MitreTechnique {
     id: string;
     name: string;

--- a/src/validation/validator.ts
+++ b/src/validation/validator.ts
@@ -532,8 +532,9 @@ export class SentinelRuleValidator {
             return false;
         }
 
-        // Must be a YAML file
-        if (document.languageId !== 'yaml') {
+        // Must be YAML content: plain YAML, or the custom `sentinel-rule`
+        // language bound to *.sentinel.yaml files.
+        if (document.languageId !== 'yaml' && document.languageId !== 'sentinel-rule') {
             return false;
         }
 


### PR DESCRIPTION
## Summary

Makes MITRE ATT&CK tactic / technique / sub-technique IntelliSense and hover work consistently across every Sentinel-as-Code content type, and cuts release 26.7.3.

## Problem

Completion, hover, the analytics-rule validator, and content diagnostics all gated on the `yaml` language id, so files served under the custom `sentinel-rule` language (`.sentinel.yaml`) got no MITRE helpers. Technique detection also only matched lowercase `techniques`, missing `relevantTechniques` (analytics/NRT) and `mitreTechniques` (Defender detections), and technique completion was capped at 50 items.

## Changes

- Register completion + hover for both `yaml` and `sentinel-rule` languages.
- Key-anchored MITRE field detection covering `tactics`, `relevantTechniques`, `techniques`, and `mitreTechniques` (on the key line and on list items).
- Removed the 50-technique cap so all techniques and sub-techniques are suggested.
- Widened the validator and content-diagnostics language gates to include `sentinel-rule`.
- Centralised the field names in `mitreLoader` (`MITRE_TACTIC_FIELDS` / `MITRE_TECHNIQUE_FIELDS`).

## Release

- Version 26.7.3.
- New `CHANGELOG.md` (Keep a Changelog) with 26.7.3 and 26.7.2 entries.

## Testing

- `npm run compile` and `npm run lint:check` clean.
- `npm test` - 117 passing.

Merging bumps `package.json` on main, which triggers the release workflow to publish v26.7.3 as a stable release.

## Additional changes (content authoring, commit 960d4d5)

Beyond the MITRE work above, this branch now also includes:

- **Value IntelliSense for `severity`** - content-type aware: capitalised `Informational`/`Low`/`Medium`/`High` for Sentinel analytics and NRT rules, lowercase for Defender custom detections (resolved via `RuleTypeDetector`).
- **ISO 8601 duration IntelliSense** for `queryFrequency`, `queryPeriod` (5 minutes to 14 days) and `suppressionDuration` (capped at 24 hours), each shown with a human-readable label (for example `PT5H` as 5 hours).
- **New `Convert Content JSON to YAML` command** (`sentinelAsCode.convertContentToYaml`) - the inverse of the existing YAML-to-JSON command, wired into the command palette and the editor/explorer right-click menus on `.json`.
- **Command palette cleanup** - a single `New Sentinel-as-Code Content...` entry; the redundant `Generate Rule Template` picker and the individual `New Hunting Query` / `New Parser` / `New Summary Rule` / `New Automation Rule` / `Generate Custom Detection Template` entries are hidden (commands stay registered so the unified picker, context menus, and keybindings keep working).
- **Fix** - the scaffolded default `severity` is now `Medium` (was incorrectly `Low` due to an off-by-one index into `VALID_SEVERITIES`), matching the documented intent and the ARM-to-YAML converter fallback.

All additional changes are documented under 26.7.3 in `CHANGELOG.md`. `npm run compile`, `npm run lint:check`, and `npm test` (117 passing) remain clean.
